### PR TITLE
Implemented the server-owned pricing change

### DIFF
--- a/app/api/routes/orders.py
+++ b/app/api/routes/orders.py
@@ -1,11 +1,10 @@
 """Order API routes."""
 
 from datetime import datetime
-from decimal import Decimal
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Response, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -19,12 +18,16 @@ router = APIRouter(prefix="/orders", tags=["orders"])
 class OrderItemCreateRequest(BaseModel):
     """Public order item create payload."""
 
+    model_config = ConfigDict(extra="forbid")
+
     product_id: int
     quantity: int = Field(gt=0)
 
 
 class OrderCreateRequest(BaseModel):
     """Public order create payload."""
+
+    model_config = ConfigDict(extra="forbid")
 
     customer_id: int
     order_date: datetime | None = None
@@ -59,14 +62,11 @@ def create_order(
     service_payload = OrderCreate(
         customer_id=payload.customer_id,
         order_date=payload.order_date,
-        total_amount=Decimal("0.00"),
         status=payload.status,
         items=[
             OrderItemCreate(
                 product_id=item.product_id,
                 quantity=item.quantity,
-                unit_price=Decimal("0.00"),
-                line_total=Decimal("0.00"),
             )
             for item in payload.items
         ],

--- a/app/repositories/order_repository.py
+++ b/app/repositories/order_repository.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.core.exceptions import DomainValidationError, NotFoundError
 from app.models import Customer, Order, OrderItem, Product
-from app.schemas.order import OrderCreate, OrderUpdate
+from app.schemas.order import OrderPricedCreate, OrderUpdate
 
 
 class OrderRepository:
@@ -14,7 +14,7 @@ class OrderRepository:
     def __init__(self, db: Session) -> None:
         self.db = db
 
-    def create_order(self, payload: OrderCreate) -> Order:
+    def create_order(self, payload: OrderPricedCreate) -> Order:
         customer = self.db.get(Customer, payload.customer_id)
         if customer is None:
             raise NotFoundError("Customer not found")

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -6,8 +6,10 @@ from app.schemas.customer import CustomerCreate, CustomerRead, CustomerUpdate
 from app.schemas.order import (
     OrderCreate,
     OrderItemCreate,
+    OrderItemPricedCreate,
     OrderItemRead,
     OrderItemUpdate,
+    OrderPricedCreate,
     OrderRead,
     OrderUpdate,
 )
@@ -22,8 +24,10 @@ __all__ = [
     "CustomerUpdate",
     "OrderCreate",
     "OrderItemCreate",
+    "OrderItemPricedCreate",
     "OrderItemRead",
     "OrderItemUpdate",
+    "OrderPricedCreate",
     "OrderRead",
     "OrderUpdate",
     "OrmSchema",

--- a/app/schemas/order.py
+++ b/app/schemas/order.py
@@ -11,12 +11,21 @@ class OrderItemBase(OrmSchema):
 
     product_id: int
     quantity: int
+
+
+class OrderItemPricedBase(OrderItemBase):
+    """Order item fields with server-calculated pricing."""
+
     unit_price: Decimal
     line_total: Decimal
 
 
 class OrderItemCreate(OrderItemBase):
     """Payload for creating an order item."""
+
+
+class OrderItemPricedCreate(OrderItemPricedBase):
+    """Trusted payload for persisting an order item."""
 
 
 class OrderItemUpdate(OrmSchema):
@@ -28,7 +37,7 @@ class OrderItemUpdate(OrmSchema):
     line_total: Decimal | None = None
 
 
-class OrderItemRead(OrderItemBase):
+class OrderItemRead(OrderItemPricedBase):
     """Order item response payload."""
 
     id: int
@@ -44,10 +53,19 @@ class OrderBase(OrmSchema):
     status: str
 
 
-class OrderCreate(OrderBase):
+class OrderCreate(OrmSchema):
     """Payload for creating an order."""
 
+    customer_id: int
+    order_date: datetime | None = None
+    status: str
     items: list[OrderItemCreate]
+
+
+class OrderPricedCreate(OrderBase):
+    """Trusted payload for persisting an order."""
+
+    items: list[OrderItemPricedCreate]
 
 
 class OrderUpdate(OrmSchema):

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm import Session
 from app.core.exceptions import DomainValidationError
 from app.models import Order
 from app.repositories import OrderRepository, ProductRepository
-from app.schemas.order import OrderCreate, OrderItemCreate, OrderUpdate
+from app.schemas.order import (
+    OrderCreate,
+    OrderItemPricedCreate,
+    OrderPricedCreate,
+    OrderUpdate,
+)
 
 
 class OrderService:
@@ -21,7 +26,7 @@ class OrderService:
         if not payload.items:
             raise DomainValidationError("Order must include at least one item")
 
-        normalized_items: list[OrderItemCreate] = []
+        normalized_items: list[OrderItemPricedCreate] = []
         total_amount = Decimal("0.00")
         for item in payload.items:
             if item.quantity <= 0:
@@ -32,7 +37,7 @@ class OrderService:
             line_total = unit_price * item.quantity
             total_amount += line_total
             normalized_items.append(
-                OrderItemCreate(
+                OrderItemPricedCreate(
                     product_id=item.product_id,
                     quantity=item.quantity,
                     unit_price=unit_price,
@@ -40,7 +45,7 @@ class OrderService:
                 )
             )
 
-        normalized_payload = OrderCreate(
+        normalized_payload = OrderPricedCreate(
             customer_id=payload.customer_id,
             order_date=payload.order_date,
             total_amount=total_amount,

--- a/httpreq/category.http
+++ b/httpreq/category.http
@@ -1,0 +1,8 @@
+GET http://localhost:8000/categories
+###
+POST http://localhost:8000/categories
+Content-Type: application/json
+
+{
+  "name": "Electronics"
+}

--- a/httpreq/products.http
+++ b/httpreq/products.http
@@ -1,0 +1,11 @@
+GET http://localhost:8000/products
+###
+POST http://localhost:8000/products
+Content-Type: application/json
+
+{
+  "name": "Product 2",
+  "description": "Description of Product 1",
+  "price": 20,
+  "categoryId": 1
+}

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -166,6 +166,40 @@ def test_order_routes_create_list_status_update_and_delete(
     assert client.delete(f"/orders/{order['id']}").status_code == 204
 
 
+def test_order_route_rejects_client_supplied_item_prices(
+    client: TestClient,
+    api_db_session: Session,
+):
+    customer = _create_customer(api_db_session, email="price-hijack@example.com")
+    product = client.post(
+        "/products",
+        json={
+            "name": "Monitor",
+            "description": "Display",
+            "price": "100.00",
+            "category_id": None,
+        },
+    ).json()
+
+    response = client.post(
+        "/orders",
+        json={
+            "customer_id": customer.id,
+            "status": "pending",
+            "items": [
+                {
+                    "product_id": product["id"],
+                    "quantity": 2,
+                    "unit_price": "0.01",
+                    "line_total": "0.02",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+
+
 def test_report_routes_return_json_arrays(client: TestClient, api_db_session: Session):
     category = client.post("/categories", json={"name": "Furniture"}).json()
     customer = _create_customer(api_db_session, email="reports-api@example.com")

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -15,7 +15,7 @@ from app.repositories import (
 )
 from app.schemas.category import CategoryCreate, CategoryUpdate
 from app.schemas.customer import CustomerCreate, CustomerUpdate
-from app.schemas.order import OrderCreate, OrderItemCreate
+from app.schemas.order import OrderItemPricedCreate, OrderPricedCreate
 from app.schemas.product import ProductCreate, ProductUpdate
 
 
@@ -170,13 +170,13 @@ def test_order_repository_creates_nested_items_and_eager_loads_relations(db_sess
     )
 
     created = order_repository.create_order(
-        OrderCreate(
+        OrderPricedCreate(
             customer_id=customer.id,
             order_date=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
             total_amount=Decimal("399.98"),
             status="pending",
             items=[
-                OrderItemCreate(
+                OrderItemPricedCreate(
                     product_id=product.id,
                     quantity=2,
                     unit_price=Decimal("199.99"),
@@ -220,13 +220,13 @@ def test_order_repository_filters_pagination_and_status_updates(db_session):
 
     for index, status in enumerate(["pending", "pending", "shipped"], start=1):
         order_repository.create_order(
-            OrderCreate(
+            OrderPricedCreate(
                 customer_id=customer.id,
                 order_date=datetime(2026, 4, index, 9, 0, tzinfo=UTC),
                 total_amount=Decimal("89.00"),
                 status=status,
                 items=[
-                    OrderItemCreate(
+                    OrderItemPricedCreate(
                         product_id=product.id,
                         quantity=1,
                         unit_price=Decimal("89.00"),
@@ -252,13 +252,13 @@ def test_order_repository_validates_missing_entities(db_session):
 
     with pytest.raises(NotFoundError, match="Customer not found"):
         order_repository.create_order(
-            OrderCreate(
+            OrderPricedCreate(
                 customer_id=999,
                 order_date=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
                 total_amount=Decimal("10.00"),
                 status="pending",
                 items=[
-                    OrderItemCreate(
+                    OrderItemPricedCreate(
                         product_id=1,
                         quantity=1,
                         unit_price=Decimal("10.00"),
@@ -287,7 +287,7 @@ def test_order_repository_rejects_empty_item_list(db_session):
 
     with pytest.raises(DomainValidationError, match="at least one item"):
         order_repository.create_order(
-            OrderCreate(
+            OrderPricedCreate(
                 customer_id=customer.id,
                 order_date=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
                 total_amount=Decimal("0.00"),
@@ -323,13 +323,13 @@ def test_order_repository_delete_removes_order_and_items(db_session):
         )
     )
     order = order_repository.create_order(
-        OrderCreate(
+        OrderPricedCreate(
             customer_id=customer.id,
             order_date=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
             total_amount=Decimal("55.00"),
             status="pending",
             items=[
-                OrderItemCreate(
+                OrderItemPricedCreate(
                     product_id=product.id,
                     quantity=1,
                     unit_price=Decimal("55.00"),

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -36,14 +36,11 @@ def _order_payload(customer_id: int, product_id: int, quantity: int = 1) -> Orde
     return OrderCreate(
         customer_id=customer_id,
         order_date=datetime(2026, 4, 7, 12, 0, tzinfo=UTC),
-        total_amount=Decimal("0.01"),
         status="pending",
         items=[
             OrderItemCreate(
                 product_id=product_id,
                 quantity=quantity,
-                unit_price=Decimal("0.01"),
-                line_total=Decimal("0.01"),
             )
         ],
     )


### PR DESCRIPTION
Implemented the server-owned pricing change.

  Changed:

  - app/schemas/order.py: split unpriced OrderItemCreate / OrderCreate from trusted priced persistence schemas.
  - app/services/order_service.py: calculates unit_price, line_total, and total_amount from ProductRepository.
  - app/repositories/order_repository.py: now accepts the trusted priced create payload and continues persisting historical prices.
  - app/api/routes/orders.py: removed price placeholders from request mapping and forbids extra client fields on order create request models.
  - Updated unit tests, including a regression test that client-supplied unit_price / line_total is rejected with 422.
  closes #6 