### PR TITLE
Implemented the customer service and HTTP routes

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,12 +1,14 @@
 """API route modules."""
 
 from app.api.routes.categories import router as categories_router
+from app.api.routes.customers import router as customers_router
 from app.api.routes.orders import router as orders_router
 from app.api.routes.products import router as products_router
 from app.api.routes.reports import router as reports_router
 
 __all__ = [
     "categories_router",
+    "customers_router",
     "orders_router",
     "products_router",
     "reports_router",

--- a/app/api/routes/customers.py
+++ b/app/api/routes/customers.py
@@ -1,0 +1,71 @@
+"""Customer API routes."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.schemas.customer import CustomerCreate, CustomerRead, CustomerUpdate
+from app.services import CustomerService
+
+
+router = APIRouter(prefix="/customers", tags=["customers"])
+
+
+class CustomerPage(BaseModel):
+    """Paginated customer response."""
+
+    items: list[CustomerRead]
+    total: int
+    page: int
+    page_size: int
+
+
+def get_customer_service(db: Session = Depends(get_db)) -> CustomerService:
+    return CustomerService(db)
+
+
+@router.post("", response_model=CustomerRead, status_code=status.HTTP_201_CREATED)
+def create_customer(
+    payload: CustomerCreate,
+    service: Annotated[CustomerService, Depends(get_customer_service)],
+):
+    return service.create(payload)
+
+
+@router.get("", response_model=CustomerPage)
+def list_customers(
+    service: Annotated[CustomerService, Depends(get_customer_service)],
+    page: int = 1,
+    page_size: int = 20,
+):
+    items, total = service.list(page=page, page_size=page_size)
+    return CustomerPage(items=items, total=total, page=page, page_size=page_size)
+
+
+@router.get("/{customer_id}", response_model=CustomerRead)
+def get_customer(
+    customer_id: int,
+    service: Annotated[CustomerService, Depends(get_customer_service)],
+):
+    return service.get_by_id(customer_id)
+
+
+@router.put("/{customer_id}", response_model=CustomerRead)
+def update_customer(
+    customer_id: int,
+    payload: CustomerUpdate,
+    service: Annotated[CustomerService, Depends(get_customer_service)],
+):
+    return service.update(customer_id, payload)
+
+
+@router.delete("/{customer_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_customer(
+    customer_id: int,
+    service: Annotated[CustomerService, Depends(get_customer_service)],
+):
+    service.delete(customer_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.api.routes import (
     categories_router,
+    customers_router,
     orders_router,
     products_router,
     reports_router,
@@ -37,6 +38,7 @@ app.add_middleware(
 )
 
 app.include_router(categories_router)
+app.include_router(customers_router)
 app.include_router(products_router)
 app.include_router(orders_router)
 app.include_router(reports_router)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,12 +1,14 @@
 """Service layer package."""
 
 from app.services.category_service import CategoryService
+from app.services.customer_service import CustomerService
 from app.services.order_service import OrderService
 from app.services.product_service import ProductService
 from app.services.report_service import ReportService
 
 __all__ = [
     "CategoryService",
+    "CustomerService",
     "OrderService",
     "ProductService",
     "ReportService",

--- a/app/services/customer_service.py
+++ b/app/services/customer_service.py
@@ -1,0 +1,32 @@
+"""Business logic for customers."""
+
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import DomainValidationError
+from app.models import Customer
+from app.repositories import CustomerRepository
+from app.schemas.customer import CustomerCreate, CustomerUpdate
+
+
+class CustomerService:
+    """Service API for customer use cases."""
+
+    def __init__(self, db: Session) -> None:
+        self.repository = CustomerRepository(db)
+
+    def create(self, payload: CustomerCreate) -> Customer:
+        if self.repository.get_by_email(payload.email) is not None:
+            raise DomainValidationError("Customer email already exists")
+        return self.repository.create(payload)
+
+    def get_by_id(self, customer_id: int) -> Customer:
+        return self.repository.get_by_id(customer_id)
+
+    def list(self, page: int = 1, page_size: int = 20) -> tuple[list[Customer], int]:
+        return self.repository.list(page=page, page_size=page_size)
+
+    def update(self, customer_id: int, payload: CustomerUpdate) -> Customer:
+        return self.repository.update(customer_id, payload)
+
+    def delete(self, customer_id: int) -> None:
+        self.repository.delete(customer_id)

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -123,6 +123,54 @@ def test_product_routes_crud_filter_search_and_delete(client: TestClient):
     assert client.delete(f"/products/{other['id']}").status_code == 204
 
 
+def test_customer_routes_crud_list_and_reject_duplicate_email(client: TestClient):
+    create_response = client.post(
+        "/customers",
+        json={
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "email": "ada.routes@example.com",
+            "phone": "123456",
+            "address": "1 Main St",
+            "city": "London",
+            "state": "LDN",
+            "zip_code": "12345",
+        },
+    )
+    assert create_response.status_code == 201
+    customer = create_response.json()
+
+    duplicate_response = client.post(
+        "/customers",
+        json={
+            "first_name": "Duplicate",
+            "last_name": "Customer",
+            "email": "ada.routes@example.com",
+        },
+    )
+    assert duplicate_response.status_code == 422
+    assert duplicate_response.json()["error_code"] == "validation_error"
+
+    listed = client.get("/customers")
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1
+    assert listed.json()["items"][0]["email"] == "ada.routes@example.com"
+
+    fetched = client.get(f"/customers/{customer['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["id"] == customer["id"]
+
+    updated = client.put(
+        f"/customers/{customer['id']}",
+        json={"city": "Athens"},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["city"] == "Athens"
+
+    assert client.delete(f"/customers/{customer['id']}").status_code == 204
+    assert client.get(f"/customers/{customer['id']}").status_code == 404
+
+
 def test_order_routes_create_list_status_update_and_delete(
     client: TestClient,
     api_db_session: Session,

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -8,11 +8,12 @@ import pytest
 
 from app.core.exceptions import DomainValidationError, NotFoundError
 from app.schemas.category import CategoryCreate
-from app.schemas.customer import CustomerCreate
+from app.schemas.customer import CustomerCreate, CustomerUpdate
 from app.schemas.order import OrderCreate, OrderItemCreate
 from app.schemas.product import ProductCreate, ProductUpdate
 from app.services import (
     CategoryService,
+    CustomerService,
     OrderService,
     ProductService,
     ReportService,
@@ -86,6 +87,30 @@ def test_product_service_rejects_negative_prices(db_session):
                 category_id=None,
             )
         )
+
+
+def test_customer_service_crud_and_rejects_duplicate_email(db_session):
+    customer_service = CustomerService(db_session)
+
+    customer = customer_service.create(_customer_payload("customer@example.com"))
+    with pytest.raises(DomainValidationError, match="email"):
+        customer_service.create(_customer_payload("customer@example.com"))
+
+    items, total = customer_service.list()
+    fetched = customer_service.get_by_id(customer.id)
+    assert fetched.email == "customer@example.com"
+
+    updated = customer_service.update(
+        customer.id,
+        CustomerUpdate(email="updated@example.com"),
+    )
+    customer_service.delete(customer.id)
+
+    assert total == 1
+    assert items[0].id == customer.id
+    assert updated.email == "updated@example.com"
+    with pytest.raises(NotFoundError):
+        customer_service.get_by_id(customer.id)
 
 
 def test_order_service_recomputes_totals_from_product_prices(db_session):


### PR DESCRIPTION
Implemented the customer service and HTTP routes.

  Changed:

  - Added app/services/customer_service.py with duplicate-email validation on create and repository pass-throughs for read/list/update/delete.
  - Added app/api/routes/customers.py with POST, GET, PUT, and DELETE /customers endpoints plus CustomerPage.
  - Wired CustomerService and customers_router through app/services/__init__.py, app/api/routes/__init__.py, and app/main.py.
  - Added service and API tests in tests/unit/test_services.py and tests/unit/test_api_routes.py.
  closes #9 