### PR TITLE
add stock and alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,31 @@ The FastAPI app does not run `init.sql`. The PostgreSQL Docker image runs it dur
 /docker-entrypoint-initdb.d/init.sql
 ```
 
-PostgreSQL only runs files in that directory when the database volume is new and empty. If you already started PostgreSQL before `init.sql` contained the schema, recreate the local database volume so the script runs again:
+PostgreSQL only runs files in that directory when the database volume is new and empty. For existing databases, use Alembic migrations instead of deleting the Docker volume.
+
+## Database Migrations
+This project uses Alembic for in-place schema changes against existing PostgreSQL databases. Alembic reads the database connection from the same environment-backed settings as the application.
+
+For a database that was created before Alembic was added and already has the baseline tables, stamp the baseline revision once, then apply pending migrations:
 
 ```bash
-docker compose down -v
-docker compose up -d postgres
+uv run --extra dev alembic stamp 20260411_0001
+uv run --extra dev alembic upgrade head
 ```
 
-Warning: `docker compose down -v` deletes the local PostgreSQL volume and all local database data.
+For a database that is already tracked by Alembic, only run:
+
+```bash
+uv run --extra dev alembic upgrade head
+```
+
+For brand-new local Docker databases, `init.sql` still creates the full current schema during first-time PostgreSQL initialization. If you want Alembic to track that schema for future migrations, stamp it at the current head once:
+
+```bash
+uv run --extra dev alembic stamp head
+```
+
+Do not run `docker compose down -v` unless you intentionally want to delete all local PostgreSQL data.
 
 ## Planned Run Command
 Start the FastAPI application with either of these commands:

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,42 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+# The runtime URL is loaded from app.core.config in migrations/env.py.
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/app/models/product.py
+++ b/app/models/product.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKey, Numeric, String, Text
+from sqlalchemy import CheckConstraint, ForeignKey, Integer, Numeric, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
@@ -20,11 +20,23 @@ class Product(Base):
     """Sellable product."""
 
     __tablename__ = "products"
+    __table_args__ = (
+        CheckConstraint(
+            "stock_quantity >= 0",
+            name="ck_products_stock_quantity_non_negative",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     price: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    stock_quantity: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
     category_id: Mapped[int | None] = mapped_column(
         ForeignKey("categories.id"),
         nullable=True,

--- a/app/repositories/order_repository.py
+++ b/app/repositories/order_repository.py
@@ -14,10 +14,12 @@ class OrderRepository:
     def __init__(self, db: Session) -> None:
         self.db = db
 
-    def create_order(self, payload: OrderPricedCreate) -> Order:
-        customer = self.db.get(Customer, payload.customer_id)
-        if customer is None:
+    def validate_customer_exists(self, customer_id: int) -> None:
+        if self.db.get(Customer, customer_id) is None:
             raise NotFoundError("Customer not found")
+
+    def create_order(self, payload: OrderPricedCreate) -> Order:
+        self.validate_customer_exists(payload.customer_id)
 
         product_ids = [item.product_id for item in payload.items]
         if not product_ids:

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -11,6 +11,7 @@ class ProductBase(OrmSchema):
     name: str
     description: str | None = None
     price: Decimal
+    stock_quantity: int = 0
     category_id: int | None = None
 
 
@@ -24,6 +25,7 @@ class ProductUpdate(OrmSchema):
     name: str | None = None
     description: str | None = None
     price: Decimal | None = None
+    stock_quantity: int | None = None
     category_id: int | None = None
 
 

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -26,13 +26,33 @@ class OrderService:
         if not payload.items:
             raise DomainValidationError("Order must include at least one item")
 
-        normalized_items: list[OrderItemPricedCreate] = []
-        total_amount = Decimal("0.00")
+        self.order_repository.validate_customer_exists(payload.customer_id)
+
+        products = {}
+        requested_quantities: dict[int, int] = {}
         for item in payload.items:
             if item.quantity <= 0:
                 raise DomainValidationError("Order item quantity must be positive")
 
-            product = self.product_repository.get_by_id(item.product_id)
+            product = products.get(item.product_id)
+            if product is None:
+                product = self.product_repository.get_by_id(item.product_id)
+                products[item.product_id] = product
+            requested_quantities[item.product_id] = (
+                requested_quantities.get(item.product_id, 0) + item.quantity
+            )
+
+        for product_id, requested_quantity in requested_quantities.items():
+            product = products[product_id]
+            if requested_quantity > product.stock_quantity:
+                raise DomainValidationError(
+                    f"Insufficient stock for product {product_id}"
+                )
+
+        normalized_items: list[OrderItemPricedCreate] = []
+        total_amount = Decimal("0.00")
+        for item in payload.items:
+            product = products[item.product_id]
             unit_price = product.price
             line_total = unit_price * item.quantity
             total_amount += line_total
@@ -44,6 +64,9 @@ class OrderService:
                     line_total=line_total,
                 )
             )
+
+        for product_id, requested_quantity in requested_quantities.items():
+            products[product_id].stock_quantity -= requested_quantity
 
         normalized_payload = OrderPricedCreate(
             customer_id=payload.customer_id,

--- a/app/services/product_service.py
+++ b/app/services/product_service.py
@@ -18,6 +18,7 @@ class ProductService:
 
     def create(self, payload: ProductCreate) -> Product:
         self._validate_price(payload.price)
+        self._validate_stock_quantity(payload.stock_quantity)
         return self.repository.create(payload)
 
     def get_by_id(self, product_id: int) -> Product:
@@ -40,6 +41,8 @@ class ProductService:
     def update(self, product_id: int, payload: ProductUpdate) -> Product:
         if payload.price is not None:
             self._validate_price(payload.price)
+        if payload.stock_quantity is not None:
+            self._validate_stock_quantity(payload.stock_quantity)
         return self.repository.update(product_id, payload)
 
     def delete(self, product_id: int) -> None:
@@ -49,3 +52,8 @@ class ProductService:
     def _validate_price(price: Decimal) -> None:
         if price < 0:
             raise DomainValidationError("Product price cannot be negative")
+
+    @staticmethod
+    def _validate_stock_quantity(stock_quantity: int) -> None:
+        if stock_quantity < 0:
+            raise DomainValidationError("Product stock quantity cannot be negative")

--- a/init.sql
+++ b/init.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS products (
     name VARCHAR(255) NOT NULL,
     description TEXT,
     price NUMERIC(10, 2) NOT NULL CHECK (price >= 0),
+    stock_quantity INTEGER NOT NULL DEFAULT 0 CHECK (stock_quantity >= 0),
     category_id INTEGER REFERENCES categories(id)
 );
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,60 @@
+"""Alembic migration environment."""
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.core.config import get_settings
+from app.models import Base
+
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def _database_url() -> str:
+    return get_settings().database_url
+
+
+def run_migrations_offline() -> None:
+    """Run migrations without a live database connection."""
+    context.configure(
+        url=_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations with a live database connection."""
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = _database_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+revision: str = ${repr(up_revision)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/20260411_0001_baseline.py
+++ b/migrations/versions/20260411_0001_baseline.py
@@ -1,0 +1,22 @@
+"""Baseline existing schema.
+
+Revision ID: 20260411_0001
+Revises:
+Create Date: 2026-04-11 00:01:00
+"""
+
+from collections.abc import Sequence
+
+
+revision: str = "20260411_0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/migrations/versions/20260411_0002_add_product_stock_quantity.py
+++ b/migrations/versions/20260411_0002_add_product_stock_quantity.py
@@ -1,0 +1,43 @@
+"""Add product stock quantity.
+
+Revision ID: 20260411_0002
+Revises: 20260411_0001
+Create Date: 2026-04-11 00:02:00
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260411_0002"
+down_revision: str | None = "20260411_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "products",
+        sa.Column(
+            "stock_quantity",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+    )
+    op.create_check_constraint(
+        "ck_products_stock_quantity_non_negative",
+        "products",
+        "stock_quantity >= 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_products_stock_quantity_non_negative",
+        "products",
+        type_="check",
+    )
+    op.drop_column("products", "stock_quantity")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "alembic>=1.14,<2.0",
     "eralchemy[graphviz]>=1.5.0,<2.0",
     "httpx>=0.27,<1.0",
     "pytest>=8.0,<9.0",

--- a/tests/integration/test_postgres_api.py
+++ b/tests/integration/test_postgres_api.py
@@ -70,6 +70,7 @@ def test_api_order_and_report_flow_against_postgres(
             "name": "Integration Product",
             "description": "PostgreSQL-backed product",
             "price": "12.50",
+            "stock_quantity": 4,
             "category_id": category["id"],
         },
     ).json()

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -98,6 +98,7 @@ def test_product_routes_crud_filter_search_and_delete(client: TestClient):
             "name": "Python Handbook",
             "description": "Programming guide",
             "price": "25.00",
+            "stock_quantity": 4,
             "category_id": category["id"],
         },
     )
@@ -107,6 +108,7 @@ def test_product_routes_crud_filter_search_and_delete(client: TestClient):
             "name": "Desk Lamp",
             "description": "Office light",
             "price": "15.00",
+            "stock_quantity": 3,
             "category_id": None,
         },
     ).json()
@@ -115,10 +117,15 @@ def test_product_routes_crud_filter_search_and_delete(client: TestClient):
     assert filtered.status_code == 200
     assert filtered.json()["total"] == 1
     assert filtered.json()["items"][0]["name"] == "Python Handbook"
+    assert filtered.json()["items"][0]["stock_quantity"] == 4
 
-    updated = client.put(f"/products/{other['id']}", json={"price": "17.50"})
+    updated = client.put(
+        f"/products/{other['id']}",
+        json={"price": "17.50", "stock_quantity": 7},
+    )
     assert updated.status_code == 200
     assert updated.json()["price"] == "17.50"
+    assert updated.json()["stock_quantity"] == 7
 
     assert client.delete(f"/products/{other['id']}").status_code == 204
 
@@ -182,6 +189,7 @@ def test_order_routes_create_list_status_update_and_delete(
             "name": "Monitor",
             "description": "Display",
             "price": "100.00",
+            "stock_quantity": 5,
             "category_id": None,
         },
     ).json()
@@ -199,6 +207,9 @@ def test_order_routes_create_list_status_update_and_delete(
     assert order["total_amount"] == "200.00"
     assert order["items"][0]["unit_price"] == "100.00"
     assert order["items"][0]["line_total"] == "200.00"
+    product_after_order = client.get(f"/products/{product['id']}")
+    assert product_after_order.status_code == 200
+    assert product_after_order.json()["stock_quantity"] == 3
 
     listed = client.get("/orders?status=pending")
     assert listed.status_code == 200
@@ -225,6 +236,7 @@ def test_order_route_rejects_client_supplied_item_prices(
             "name": "Monitor",
             "description": "Display",
             "price": "100.00",
+            "stock_quantity": 2,
             "category_id": None,
         },
     ).json()
@@ -248,6 +260,39 @@ def test_order_route_rejects_client_supplied_item_prices(
     assert response.status_code == 422
 
 
+def test_order_route_rejects_insufficient_stock(
+    client: TestClient,
+    api_db_session: Session,
+):
+    customer = _create_customer(api_db_session, email="insufficient-stock@example.com")
+    product = client.post(
+        "/products",
+        json={
+            "name": "Monitor",
+            "description": "Display",
+            "price": "100.00",
+            "stock_quantity": 1,
+            "category_id": None,
+        },
+    ).json()
+
+    response = client.post(
+        "/orders",
+        json={
+            "customer_id": customer.id,
+            "status": "pending",
+            "items": [{"product_id": product["id"], "quantity": 2}],
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error_code"] == "validation_error"
+    product_after_order = client.get(f"/products/{product['id']}")
+    assert product_after_order.json()["stock_quantity"] == 1
+    listed = client.get("/orders")
+    assert listed.json()["total"] == 0
+
+
 def test_report_routes_return_json_arrays(client: TestClient, api_db_session: Session):
     category = client.post("/categories", json={"name": "Furniture"}).json()
     customer = _create_customer(api_db_session, email="reports-api@example.com")
@@ -257,6 +302,7 @@ def test_report_routes_return_json_arrays(client: TestClient, api_db_session: Se
             "name": "Chair",
             "description": "Office chair",
             "price": "55.00",
+            "stock_quantity": 2,
             "category_id": category["id"],
         },
     ).json()

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -94,15 +94,17 @@ def test_product_repository_update_and_delete(db_session):
             name="Mouse",
             description="Wireless mouse",
             price=Decimal("12.99"),
+            stock_quantity=5,
             category_id=None,
         )
     )
 
     updated = product_repository.update(
         product.id,
-        ProductUpdate(price=Decimal("14.99")),
+        ProductUpdate(price=Decimal("14.99"), stock_quantity=7),
     )
     assert updated.price == Decimal("14.99")
+    assert updated.stock_quantity == 7
 
     product_repository.delete(product.id)
     with pytest.raises(NotFoundError):

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -57,16 +57,18 @@ def test_category_and_product_services_wrap_crud(db_session):
             name="USB Cable",
             description="Braided cable",
             price=Decimal("8.50"),
+            stock_quantity=10,
             category_id=category.id,
         )
     )
     updated = product_service.update(
         product.id,
-        ProductUpdate(price=Decimal("9.25")),
+        ProductUpdate(price=Decimal("9.25"), stock_quantity=12),
     )
     items, total = product_service.list(category_id=category.id, search="usb")
 
     assert updated.price == Decimal("9.25")
+    assert updated.stock_quantity == 12
     assert total == 1
     assert items[0].id == product.id
 
@@ -87,6 +89,33 @@ def test_product_service_rejects_negative_prices(db_session):
                 category_id=None,
             )
         )
+
+
+def test_product_service_rejects_negative_stock(db_session):
+    product_service = ProductService(db_session)
+
+    with pytest.raises(DomainValidationError, match="stock"):
+        product_service.create(
+            ProductCreate(
+                name="Invalid",
+                description=None,
+                price=Decimal("1.00"),
+                stock_quantity=-1,
+                category_id=None,
+            )
+        )
+
+    product = product_service.create(
+        ProductCreate(
+            name="Valid",
+            description=None,
+            price=Decimal("1.00"),
+            stock_quantity=1,
+            category_id=None,
+        )
+    )
+    with pytest.raises(DomainValidationError, match="stock"):
+        product_service.update(product.id, ProductUpdate(stock_quantity=-1))
 
 
 def test_customer_service_crud_and_rejects_duplicate_email(db_session):
@@ -124,6 +153,7 @@ def test_order_service_recomputes_totals_from_product_prices(db_session):
             name="Desk",
             description="Standing desk",
             price=Decimal("120.00"),
+            stock_quantity=5,
             category_id=None,
         )
     )
@@ -133,6 +163,29 @@ def test_order_service_recomputes_totals_from_product_prices(db_session):
     assert order.total_amount == Decimal("360.00")
     assert order.order_items[0].unit_price == Decimal("120.00")
     assert order.order_items[0].line_total == Decimal("360.00")
+    assert product.stock_quantity == 2
+
+
+def test_order_service_rejects_insufficient_stock(db_session):
+    from app.repositories import CustomerRepository
+
+    product_service = ProductService(db_session)
+    order_service = OrderService(db_session)
+    customer = CustomerRepository(db_session).create(_customer_payload("stock@example.com"))
+    product = product_service.create(
+        ProductCreate(
+            name="Desk",
+            description="Standing desk",
+            price=Decimal("120.00"),
+            stock_quantity=2,
+            category_id=None,
+        )
+    )
+
+    with pytest.raises(DomainValidationError, match="Insufficient stock"):
+        order_service.create_order(_order_payload(customer.id, product.id, quantity=3))
+
+    assert product.stock_quantity == 2
 
 
 def test_order_service_rejects_non_positive_quantities(db_session):
@@ -146,6 +199,7 @@ def test_order_service_rejects_non_positive_quantities(db_session):
             name="Mouse Pad",
             description=None,
             price=Decimal("4.00"),
+            stock_quantity=1,
             category_id=None,
         )
     )
@@ -165,6 +219,7 @@ def test_order_service_list_status_update_and_delete(db_session):
             name="Headphones",
             description=None,
             price=Decimal("60.00"),
+            stock_quantity=1,
             category_id=None,
         )
     )
@@ -196,6 +251,7 @@ def test_report_service_returns_json_ready_core_reports(db_session):
             name="Chair",
             description="Office chair",
             price=Decimal("55.00"),
+            stock_quantity=2,
             category_id=category.id,
         )
     )

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,20 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -351,6 +365,92 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "my-python-pg-project"
 version = "0.1.0"
 source = { editable = "." }
@@ -366,6 +466,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "alembic" },
     { name = "eralchemy", extra = ["graphviz"] },
     { name = "httpx" },
     { name = "pytest" },
@@ -374,6 +475,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", marker = "extra == 'dev'", specifier = ">=1.14,<2.0" },
     { name = "eralchemy", extras = ["graphviz"], marker = "extra == 'dev'", specifier = ">=1.5.0,<2.0" },
     { name = "fastapi", specifier = ">=0.115,<1.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<1.0" },


### PR DESCRIPTION
Implemented simple product inventory.

  Changed:

  - app/models/product.py: added stock_quantity with default 0, server default, and non-negative CheckConstraint.
  - app/schemas/product.py: added stock_quantity to product create/read/update schemas.
  - app/services/product_service.py: rejects negative stock on create/update.
  - app/services/order_service.py: validates available stock, aggregates duplicate product quantities, decrements stock on successful order creation, and keeps
    existing server-side price calculation.
  - app/repositories/order_repository.py: added a customer existence helper so order service can validate before mutating stock.
  - init.sql: added stock_quantity INTEGER NOT NULL DEFAULT 0 CHECK (stock_quantity >= 0) to products.
  - Updated unit and integration tests for product stock exposure, stock updates, stock depletion, and insufficient-stock failures.

  Verification:

  - uv run pytest tests/unit passed: 25 passed.
  - uv run pytest tests/integration/test_postgres_api.py passed: 3 passed.
  - git diff --check passed.

  Note: because this project uses init.sql rather than migrations, existing local PostgreSQL volumes will need a manual schema update or recreation to get the new
  stock_quantity column.
Implemented Alembic migrations for the project.

  Added:

  - alembic.ini
  - migrations/env.py
  - migrations/script.py.mako
  - migrations/versions/20260411_0001_baseline.py
  - migrations/versions/20260411_0002_add_product_stock_quantity.py

  Also updated:

  - pyproject.toml and uv.lock to include Alembic in dev dependencies.
  - README.md with migration commands:
      - Existing pre-Alembic DB: uv run --extra dev alembic stamp 20260411_0001, then uv run --extra dev alembic upgrade head
      - Already tracked DB: uv run --extra dev alembic upgrade head
      - Fresh DB created from current init.sql: uv run --extra dev alembic stamp head
closes #7 